### PR TITLE
bugfix: tracking loop

### DIFF
--- a/arduino/Arduino.h
+++ b/arduino/Arduino.h
@@ -1,6 +1,9 @@
 #ifndef ARDUINO_H
 #define ARDUINO_H
 
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
 #ifndef __AVR__
 #include <cmath>
 #endif

--- a/src/TrackingLoop.cpp
+++ b/src/TrackingLoop.cpp
@@ -4,7 +4,7 @@
 
 /**
  * @brief Construct a new Tracking Loop object
- * 
+ *
  */
 TrackingLoop::TrackingLoop()
 {
@@ -13,7 +13,7 @@ TrackingLoop::TrackingLoop()
     this->ki = 900.0;
     this->vel_pid.begin(0, this->kp, this->ki, 0);
     this->accel_pid.begin(0, this->kp, this->ki, 0);
-    
+
     // Unbounded output required on the PID
     this->vel_pid.setBounded(false);
     this->accel_pid.setBounded(false);
@@ -27,7 +27,7 @@ TrackingLoop::TrackingLoop()
 
 /**
  * @brief Construct a new Tracking Loop object with PI gains
- * 
+ *
  * @param kp proportional gain
  * @param ki integral gain
  */
@@ -52,7 +52,7 @@ TrackingLoop::TrackingLoop(float kp, float ki)
 
 /**
  * @brief Copy assignment operation
- * 
+ *
  * @param tracker another tracking loop
  */
 void TrackingLoop::operator=(const TrackingLoop& tracker)
@@ -63,7 +63,7 @@ void TrackingLoop::operator=(const TrackingLoop& tracker)
     this->vel_pid = tracker.vel_pid;
     this->kp = tracker.kp;
     this->ki = tracker.ki;
-    
+
     // Timing
     this->last_time = tracker.last_time;
 
@@ -76,7 +76,7 @@ void TrackingLoop::operator=(const TrackingLoop& tracker)
 
 /**
  * @brief Resets the tracking loop
- * 
+ *
  */
 void TrackingLoop::reset()
 {
@@ -98,7 +98,7 @@ void TrackingLoop::reset()
 
 /**
  * @brief Updates the tracking loop with a position measurement
- * 
+ *
  * @param measurement the encoder position
  */
 void TrackingLoop::update(float measurement)
@@ -108,8 +108,8 @@ void TrackingLoop::update(float measurement)
     float model_vel;
 
     // Get the elapsed time (sec)
-    dt = (float)(millis() - this->last_time) / 1000.0;
-    
+    dt = max((float)(millis() - this->last_time), 1.0) / 1000.0;
+
     // Estimate the position and velocity from the state estimates
     this->pos_estimate += this->vel_estimate * dt;
     model_vel = this->vel_estimate + (this->accel_estimate * dt);
@@ -126,8 +126,19 @@ void TrackingLoop::update(float measurement)
 
 
 /**
+ * @brief Get the position estimate for this tracker
+ *
+ * @return float position estimate
+ */
+float TrackingLoop::getPositionEstimate()
+{
+    return this->pos_estimate;
+}
+
+
+/**
  * @brief Get the velocity estimate for this tracker
- * 
+ *
  * @return float velocity estimate
  */
 float TrackingLoop::getVelocityEstimate()
@@ -138,7 +149,7 @@ float TrackingLoop::getVelocityEstimate()
 
 /**
  * @brief Get an acceleration estimate from the tracker
- * 
+ *
  * @return float acceleration estimate
  */
 float TrackingLoop::getAccelEstimate()

--- a/src/TrackingLoop.cpp
+++ b/src/TrackingLoop.cpp
@@ -108,7 +108,7 @@ void TrackingLoop::update(float measurement)
     float model_vel;
 
     // Get the elapsed time (sec)
-    dt = max((float)(millis() - this->last_time), 1.0) / 1000.0;
+    dt = fmax((float)(millis() - this->last_time), 1.0) / 1000.0;
 
     // Estimate the position and velocity from the state estimates
     this->pos_estimate += this->vel_estimate * dt;

--- a/src/TrackingLoop.h
+++ b/src/TrackingLoop.h
@@ -19,6 +19,7 @@ class TrackingLoop
         void update(float measurement);
 
         // Accessors
+        float getPositionEstimate();
         float getVelocityEstimate();
         float getAccelEstimate();
 

--- a/tests/test_tracking_loop.cpp
+++ b/tests/test_tracking_loop.cpp
@@ -9,6 +9,7 @@ TEST_CASE("TrackingLoop: Reset Test")
     tracker.reset();
 
     // Estimations should be 0
+    REQUIRE(tracker.getPositionEstimate() == Approx(0.0f));
     REQUIRE(tracker.getVelocityEstimate() == Approx(0.0f));
     REQUIRE(tracker.getAccelEstimate() == Approx(0.0f));
 }
@@ -20,6 +21,7 @@ TEST_CASE("TrackingLoop: Initialize Test")
     TrackingLoop tracker1;
 
     // Estimations should be 0
+    REQUIRE(tracker1.getPositionEstimate() == Approx(0.0f));
     REQUIRE(tracker1.getVelocityEstimate() == Approx(0.0f));
     REQUIRE(tracker1.getAccelEstimate() == Approx(0.0f));
 
@@ -27,6 +29,7 @@ TEST_CASE("TrackingLoop: Initialize Test")
     TrackingLoop tracker2(100, 500);
 
     // Estimations should be 0
+    REQUIRE(tracker2.getPositionEstimate() == Approx(0.0f));
     REQUIRE(tracker2.getVelocityEstimate() == Approx(0.0f));
     REQUIRE(tracker2.getAccelEstimate() == Approx(0.0f));
 }
@@ -36,13 +39,14 @@ TEST_CASE("TrackingLoop: Copy-Assign Test")
 {
     // Default tracker
     TrackingLoop tracker1, tracker2;
-    float vel, accel;
+    float pos, vel, accel;
 
     // Add a short timestep
     addArduinoTimeMillis(1.0);
 
     // Run a loop and get the estimates
     tracker1.update(5);
+    pos = tracker1.getPositionEstimate();
     vel = tracker1.getVelocityEstimate();
     accel = tracker1.getAccelEstimate();
 
@@ -50,6 +54,7 @@ TEST_CASE("TrackingLoop: Copy-Assign Test")
     tracker2 = tracker1;
 
     // Tracker 2 estimates should be equal to tracker 1
+    REQUIRE(tracker2.getPositionEstimate() == Approx(pos));
     REQUIRE(tracker2.getVelocityEstimate() == Approx(vel));
     REQUIRE(tracker2.getAccelEstimate() == Approx(accel));
 }


### PR DESCRIPTION
Adds lower bound to dt on tracking loop to avoid division by 0. Also adds a position estimate output function

Worth considering changing the default PI constants because they cause this controller to make the measurement system unstable (diverge to infinity).