### PR TITLE
Add encoder resolution option

### DIFF
--- a/examples/Quadrature_Encoder_Basic/Quadrature_Encoder_Basic.ino
+++ b/examples/Quadrature_Encoder_Basic/Quadrature_Encoder_Basic.ino
@@ -22,10 +22,11 @@ void pinAInterrupt() {
 // Setup happens only once, when the Arduino is first powered on or reset.
 void setup() {
   // Initialize encoder on pins 1 and 2 with K-value 3.5.
+  // Default encoder resolution is 2x.
   encoder.begin(1, 2, 3.5);
 
   // Attach an interrupt to pin 1 to call pinAInterrupt.
-  attachInterrupt(digitalPinToInterrupt(1), pinAInterrupt, RISING);
+  attachInterrupt(digitalPinToInterrupt(1), pinAInterrupt, CHANGE);
 
   // Begin serial so we can communicate with PC
   Serial.begin(9600);

--- a/src/QuadratureEncoder.h
+++ b/src/QuadratureEncoder.h
@@ -17,6 +17,7 @@ class QuadratureEncoder : public Encoder
         /* Configuration */
         void begin(int A, int B, float K);
         void begin(int A, int B, float K, int pullup);
+        void setResolution(int resolution);
         void pullup();
         void process();
         void reset();
@@ -26,8 +27,12 @@ class QuadratureEncoder : public Encoder
         float getValue();
 
     private:
+        // Configuration
+        int resolution = 2;
+
         // Position
-        long ticks;
+        volatile long ticks;
+        int lastState = 0;
         float K;
 
         // Pins

--- a/tests/test_quadrature_encoder.cpp
+++ b/tests/test_quadrature_encoder.cpp
@@ -45,9 +45,10 @@ TEST_CASE("QuadratureEncoder: Begin Test")
     REQUIRE(getModeAtPin(2) == INPUT_PULLUP);
 }
 
-TEST_CASE("QuadratureEncoder: Process Input Test")
+TEST_CASE("QuadratureEncoder: X1 Resolution Process Input Test")
 {
     QuadratureEncoder quad(1, 2, 3);
+    quad.setResolution(1);
 
     // Simulate forward motion
     setValueAtPin(1, HIGH);
@@ -74,6 +75,78 @@ TEST_CASE("QuadratureEncoder: Process Input Test")
 
     REQUIRE(quad.getTicks() == -10);
     REQUIRE(quad.getValue() == Approx(-30.0));
+}
+
+TEST_CASE("QuadratureEncoder: X2 Resolution Process Input Test")
+{
+    QuadratureEncoder quad(1, 2, 3);
+    quad.setResolution(2);
+
+    // Simulate forward motion
+    int states[2] = {0b11, 0b00};
+
+    // Run 10 ticks forward
+    for(int i = 0; i < 10; ++i)
+    {
+        setValueAtPin(1, (states[i%2] & 0b10) >> 1);
+        setValueAtPin(2, states[i%2] & 0b01);
+        quad.process();
+    }
+
+    REQUIRE(quad.getTicks() == 10);
+    REQUIRE(quad.getValue() == Approx(30.0));
+
+    // Simulate forward motion
+    int states2[2] = {0b10, 0b01};
+
+    // Run 20 ticks backward
+    // Note that the first tick will go from (00 to 10) which is invalid
+    // and thus ignored. So we do 21 pulses to go back 20 ticks.
+    for(int i = 0; i < 21; ++i)
+    {
+        setValueAtPin(1, (states2[i%2] & 0b10) >> 1);
+        setValueAtPin(2, states2[i%2] & 0b01);
+        quad.process();
+    }
+
+    REQUIRE(quad.getTicks() == -10);
+    REQUIRE(quad.getValue() == Approx(-30.0));
+}
+
+TEST_CASE("QuadratureEncoder: X4 Resolution Process Input Test")
+{
+    QuadratureEncoder quad(1, 2, 3);
+    quad.setResolution(4);
+
+    // Simulate forward motion
+    int states[4] = {0b01, 0b11, 0b10, 0b00};
+
+    // Run 12 ticks forward
+    for(int i = 0; i < 12; ++i)
+    {
+        setValueAtPin(1, (states[i%4] & 0b10) >> 1);
+        setValueAtPin(2, states[i%4] & 0b01);
+        quad.process();
+    }
+
+    REQUIRE(quad.getTicks() == 12);
+    REQUIRE(quad.getValue() == Approx(36.0));
+
+    // Simulate forward motion
+    int states2[4] = {0b00, 0b10, 0b11, 0b01};
+
+    // Run 24 ticks backward
+    // Note that the first tick will go from (00 to 00) which is invalid
+    // and thus ignored. So we do 21 pulses to go back 20 ticks.
+    for(int i = 0; i < 25; ++i)
+    {
+        setValueAtPin(1, (states2[i%4] & 0b10) >> 1);
+        setValueAtPin(2, states2[i%4] & 0b01);
+        quad.process();
+    }
+
+    REQUIRE(quad.getTicks() == -12);
+    REQUIRE(quad.getValue() == Approx(-36.0));
 }
 
 TEST_CASE("QuadratureEncoder: Reset Test")
@@ -115,6 +188,7 @@ TEST_CASE("QuadratureEncoder: Pullup Test")
 TEST_CASE("QuadratureEncoder: Copy-Assign Test")
 {
     QuadratureEncoder quad1(1, 2, 3), quad2;
+    quad1.setResolution(1);
 
     // Simulate forward motion
     setValueAtPin(1, HIGH);


### PR DESCRIPTION
- Add options to change the resolution for a QuadratureEncoder. 1x, 2x, or 4x. Defaults to 2x.
- Slightly updates example to work with 2x resolution.
- Add testing for 2x and 4x resolution