### PR TITLE
Fixes misleading variable naming in PID header file

### DIFF
--- a/src/PIDController.h
+++ b/src/PIDController.h
@@ -21,7 +21,7 @@ class PIDController
         void begin(float init_state, float kp, float ki, float kd);
         void reset();
         void setBounded(bool bounded);
-        void setOutputRange(float upper, float lower);
+        void setOutputRange(float lower, float upper);
         void setTolerance(float setpoint_tol, float derivative_tol, bool apply_tolerance);
         void setIntegratorBounds(float min, float max);
 


### PR DESCRIPTION
Lower and upper are no longer switched in the header file, which is much nicer. VS Code was telling me upper was the first argument which produced obviously wrong answers.